### PR TITLE
Fix multiply method in CoolCalc class

### DIFF
--- a/calculator/coolcalc.py
+++ b/calculator/coolcalc.py
@@ -9,4 +9,4 @@ class CoolCalc(object):
 
     def multiply_a_b(self, a, b):
         """Take two numbers and return the product."""
-        return a + b
+        return a * b


### PR DESCRIPTION
Issue originally referenced in #1.  The `multiply_a_b` method in `coolcalc.py` has been fixed to actually calculate the product of two numbers instead of the sum.  All tests are passing locally for me.